### PR TITLE
update captureIntervalTime

### DIFF
--- a/motiondetector.js
+++ b/motiondetector.js
@@ -43,6 +43,7 @@ Module.register('motiondetector',{
 
 			DiffCamEngine.init({
 				video: video,
+				captureIntervalTime: 1000,
 				motionCanvas: canvas,
 				initSuccessCallback: function () {
 					DiffCamEngine.start();

--- a/motiondetector.js
+++ b/motiondetector.js
@@ -71,9 +71,6 @@ Module.register('motiondetector',{
 					}
 					console.log('score:' + score);
 				}
-			});
-     		        
+			});     		        
 	},
-
-
 });


### PR DESCRIPTION
Users have reported memory lag system crashes caused by the default value.  This change is a confirmed fix.